### PR TITLE
Fixed issue with lag spike every time someone dies

### DIFF
--- a/Genji-Dodgeball.opy
+++ b/Genji-Dodgeball.opy
@@ -303,6 +303,7 @@ rule "Create global HUD elements":
     hudSubtext([player for player in getAllPlayers() if BallSpeed > 55], "Current Ball Speed: {0}".format(BallSpeed), HudPosition.LEFT, -3, Color.PURPLE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
     #hudSubheader(getAllPlayers(), "Updates by u/FearlessKat, u/Blink, u/TheRedstoneBlaze, tumtum9000#1232,david8686406#1523", HudPosition.LEFT, -10, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
     hudSubtext(getAllPlayers(), "Discord.gg/GenjiDodgeball", HudPosition.LEFT, 0, Color.WHITE, HudReeval.VISIBILITY, SpecVisibility.DEFAULT)
+    createInWorldText([player for player in getAllPlayers() if BallSpawnCountdown != 0], "Ball Spawning In: {0}".format(ceil(BallSpawnCountdown)), vect(CircleCenter.x, CircleCenter.y + 2.5, CircleCenter.z), 2.5, Clip.SURFACES, WorldTextReeval.VISIBILITY_AND_STRING, Color.SKY_BLUE, SpecVisibility.DEFAULT)
     if PassingEnabled:
         if getCurrentGamemode() == Gamemode.TDM:
             hudSubtext(getAllPlayers(), "Hold secondary fire while deflecting to pass the ball to another teammate!", HudPosition.RIGHT, 0, Color.WHITE, HudReeval.VISIBILITY, SpecVisibility.DEFAULT)
@@ -406,12 +407,6 @@ rule "Create ball & targeted effect - TEAMS":
     #BallTail2 = getLastCreatedEntity()
     createEffect([i for i in [player for player in getAllPlayers() if player != TargetedPlayer] if IsPassingTeam1 or IsPassingTeam2], Effect.GOOD_AURA, Color.SKY_BLUE, BallPosition, 1, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
     createEffect([player for player in getAllPlayers() if player != TargetedPlayer and (IsPassingTeam1 or IsPassingTeam2)], Effect.GOOD_AURA, Color.SKY_BLUE, TargetedPlayer, 1, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
-
-
-rule "Create ball countdown HUD":
-    @Condition BallSpawnCountdown > 0
-    
-    createInWorldText([player for player in getAllPlayers() if BallSpawnCountdown != 0], "Ball Spawning In: {0}".format(ceil(BallSpawnCountdown)), vect(CircleCenter.x, CircleCenter.y + 2.5, CircleCenter.z), 2.5, Clip.SURFACES, WorldTextReeval.VISIBILITY_AND_STRING, Color.SKY_BLUE, SpecVisibility.DEFAULT)
 
 
 rule "Enable Scoreboard":

--- a/Genji-Dodgeball.opy
+++ b/Genji-Dodgeball.opy
@@ -1,6 +1,6 @@
 settings {
     "main": {
-        "description": "Genji Dodgeball v7.1.0. Developed by u/Mazawath. Numerous updates by u/FearlessKat, u/Blink, u/TheRedstoneBlaze,  ELIMINATED#1572, and tumtum9000#1232. Deflect the ball when it is red to target someone else! Use jump pads to get air!"
+        "description": "Genji Dodgeball v7.1.1. Developed by u/Mazawath. Numerous updates by u/FearlessKat, u/Blink, u/TheRedstoneBlaze,  ELIMINATED#1572, and tumtum9000#1232. Deflect the ball when it is red to target someone else! Use jump pads to get air!"
     },
     "lobby": {
         "allowPlayersInQueue": true,
@@ -434,7 +434,7 @@ rule "Disable Scoreboard":
 rule "// Not enough players testing":
     if not WatermarkEnabled:
         goto lbl_0
-    hudSubheader(getAllPlayers(), "Original by u/Mazawrath. Version v7.1.0", HudPosition.LEFT, -1000, Color.AQUA, HudReeval.VISIBILITY, SpecVisibility.ALWAYS)
+    hudSubheader(getAllPlayers(), "Original by u/Mazawrath. Version v7.1.1", HudPosition.LEFT, -1000, Color.AQUA, HudReeval.VISIBILITY, SpecVisibility.ALWAYS)
     lbl_0:
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Overwatch-Genji-Dodgeball
-**Current Version: v7.1.0**  
+**Current Version: v7.1.1**  
 **Deathmatch Code: B4TPX**  
 
 Genji Dodgeball is a minigame inspired by the TF2 game pyro dodgeball.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Overwatch-Genji-Dodgeball
 **Current Version: v7.1.1**  
-**Deathmatch Code: B4TPX**  
+**Deathmatch Code: 8H59R**  
 
 Genji Dodgeball is a minigame inspired by the TF2 game pyro dodgeball.
 When the ball is red it is targeting you! Use your deflect to target someone else. Look at the person you want to target next while deflecting. Use bouncepads to get extra air and style points.
 
 ## Team Deathmatch  
-**Team Deathmatch Code: TTAEH**  
+**Team Deathmatch Code: 2SS96**  
 The Team Deathmatch version is a version where passing is enabled by default. To pass, hold the Secondary Fire button. The ball with pass to another teammate or if none are alive, it will pass it to yourself. Each pass will cost 100 health, you can get healed by deflecting the ball to a enemy, or someone on either team dies.  
 
 ## How to compile  


### PR DESCRIPTION
This was due to the fact that every single time the ball spawn countdown wasn't 0, it would create in world text to show the countdown, but it never deleted that text.